### PR TITLE
bug fix

### DIFF
--- a/client/src/hooks/useLocalStorage.js
+++ b/client/src/hooks/useLocalStorage.js
@@ -1,22 +1,28 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from "react";
 
-const PREFIX = 'whatsapp-clone-'
+const PREFIX = "whatsapp-clone-";
 
 export default function useLocalStorage(key, initialValue) {
-  const prefixedKey = PREFIX + key
+  const prefixedKey = PREFIX + key;
   const [value, setValue] = useState(() => {
-    const jsonValue = localStorage.getItem(prefixedKey)
-    if (jsonValue != null) return JSON.parse(jsonValue)
-    if (typeof initialValue === 'function') {
-      return initialValue()
-    } else {
-      return initialValue
+    const jsonValue = localStorage.getItem(prefixedKey);
+    if (jsonValue != null) {
+      if (jsonValue === "undefined") {
+        return null;
+      } else {
+        return JSON.parse(jsonValue);
+      }
     }
-  })
+    if (typeof initialValue === "function") {
+      return initialValue();
+    } else {
+      return initialValue;
+    }
+  });
 
   useEffect(() => {
-    localStorage.setItem(prefixedKey, JSON.stringify(value))
-  }, [prefixedKey, value])
+    localStorage.setItem(prefixedKey, JSON.stringify(value));
+  }, [prefixedKey, value]);
 
-  return [value, setValue]
+  return [value, setValue];
 }


### PR DESCRIPTION
Hey !! When the user reloads the login page it showed a cross-origin error. So i figured out that it was due to custom hook which sets it value from local storage. When the window is opened the variable is being stored but has the value undefined. So when the user and tries to get data the error case of value undefined is not handled in useLocalStorage hook. I hope it helps. I have learnt from you ;). Keep making awesome clone videos